### PR TITLE
位置情報を検索し緯度経度を取得する #43

### DIFF
--- a/MyMap/MyMap/ContentView.swift
+++ b/MyMap/MyMap/ContentView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct ContentView: View {
     var body: some View {
         VStack {
-            MapView()
+            MapView(searchKey: "TOKYO SKYTREE")
         }
     }
 }

--- a/MyMap/MyMap/MapView.swift
+++ b/MyMap/MyMap/MapView.swift
@@ -9,17 +9,30 @@ import SwiftUI
 import MapKit
 
 struct MapView: UIViewRepresentable {
-    
+    let searchKey: String
     func makeUIView(context: Context) -> MKMapView {
         MKMapView()
     }
     func updateUIView(_ uiView: MKMapView, context: Context) {
-        
+        print(searchKey)
+        let geocoder = CLGeocoder()
+        geocoder.geocodeAddressString(searchKey, completionHandler: { (placemarks, error) in
+            print("placemarks: \(placemarks?.count)")
+            print("error: \(error?.localizedDescription)")
+            // リクエストの結果が存在すれば、1件目の位置情報から取り出す
+            if let unwrapPlacemarks = placemarks,
+               let firstPlacemark = unwrapPlacemarks.first,
+               let location = firstPlacemark.location {
+                let targetCoordinate = location.coordinate
+                print("targetCoordinate: \(targetCoordinate)")
+            }
+            
+        })
     }
 }
 
 struct MapView_Previews: PreviewProvider {
     static var previews: some View {
-        MapView()
+        MapView(searchKey: "TOKYO SKYTREE")
     }
 }


### PR DESCRIPTION
Log
```
2022-04-28 18:12:03.322413+0900 MyMap[24476:693335] Metal API Validation Enabled
TOKYO SKYTREE
2022-04-28 18:12:03.397601+0900 MyMap[24476:693445] [Client] {"msg":"#NullIsland Received a latitude or longitude from getLocationForBundleID that was exactly zero", "latIsZero":0, "lonIsZero":0, "location":'D0 76 5A 08 00 70 00 00'}
placemarks: Optional(1)
error: nil
targetCoordinate: CLLocationCoordinate2D(latitude: 35.689506, longitude: 139.6917)
```


close #43 